### PR TITLE
Implement FastAPI backend using SQLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# Lead Qualifier 
+# Lead Qualifier
+
+This repository contains a minimal backend implementation for the Growth AI Engineer take-home challenge. It exposes API endpoints using **FastAPI**, stores data in **SQLite** via **SQLAlchemy**, and loads the provided `leads.csv` into the database on startup.
+
+## Running the API
+
+1. Install dependencies:
+
+```bash
+pip install -r backend/requirements.txt
+```
+
+2. Start the development server:
+
+```bash
+uvicorn backend.app:app --reload
+```
+
+The API will be available at `http://localhost:8000`.

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,68 @@
+from datetime import datetime
+import json
+
+from fastapi import FastAPI, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from .models import Lead, Event, SessionLocal, init_db
+
+app = FastAPI(title="Lead Qualifier API")
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@app.on_event("startup")
+def on_startup():
+    init_db()
+
+
+class LeadOut(BaseModel):
+    id: int
+    name: str
+    company: str
+    industry: str
+    size: int
+    source: str
+    created_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class EventIn(BaseModel):
+    userId: str = Field(..., alias="userId")
+    action: str
+    metadata: dict = Field(default_factory=dict)
+    timestamp: datetime
+
+
+@app.get("/api/leads", response_model=list[LeadOut])
+def get_leads(industry: str | None = None, size: int | None = None, db: Session = Depends(get_db)):
+    query = db.query(Lead)
+    if industry:
+        query = query.filter(Lead.industry == industry)
+    if size:
+        query = query.filter(Lead.size >= size)
+    leads = query.all()
+    return leads
+
+
+@app.post("/api/events", status_code=201)
+def create_event(event: EventIn, db: Session = Depends(get_db)):
+    db_event = Event(
+        user_id=event.userId,
+        action=event.action,
+        metadata=json.dumps(event.metadata),
+        occurred_at=event.timestamp,
+    )
+    db.add(db_event)
+    db.commit()
+    db.refresh(db_event)
+    return {"status": "ok", "id": db_event.id}

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,68 @@
+from datetime import datetime
+import csv
+import os
+from typing import Optional
+
+from sqlalchemy import create_engine, Column, Integer, String, DateTime, Text
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DB_PATH = os.path.join(BASE_DIR, 'data', 'app.db')
+CSV_PATH = os.path.join(BASE_DIR, 'data', 'leads.csv')
+
+DATABASE_URL = f"sqlite:///{DB_PATH}"
+
+engine = create_engine(
+    DATABASE_URL, connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+
+class Lead(Base):
+    __tablename__ = 'leads'
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String)
+    company = Column(String)
+    industry = Column(String)
+    size = Column(Integer)
+    source = Column(String)
+    created_at = Column(DateTime)
+
+
+class Event(Base):
+    __tablename__ = 'events'
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(String)
+    action = Column(String)
+    metadata = Column(Text)
+    occurred_at = Column(DateTime, default=datetime.utcnow)
+
+
+def init_db():
+    """Create tables and load leads from CSV on first run."""
+    Base.metadata.create_all(bind=engine)
+    db = SessionLocal()
+    try:
+        has_leads = db.query(Lead).first() is not None
+        if not has_leads and os.path.exists(CSV_PATH):
+            with open(CSV_PATH, newline='') as f:
+                reader = csv.DictReader(f)
+                for row in reader:
+                    created = datetime.fromisoformat(row['created_at'].replace('Z', ''))
+                    db_lead = Lead(
+                        id=int(row['id']),
+                        name=row['name'],
+                        company=row['company'],
+                        industry=row['industry'],
+                        size=int(row['size']),
+                        source=row['source'],
+                        created_at=created,
+                    )
+                    db.add(db_lead)
+            db.commit()
+    finally:
+        db.close()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+sqlalchemy
+pydantic


### PR DESCRIPTION
## Summary
- add FastAPI app with `/api/leads` and `/api/events`
- define SQLAlchemy models for leads and events
- load `leads.csv` into SQLite on startup
- provide install/run instructions in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eb116967c8325b7465348e9b49ccd