### PR TITLE
Fix reserved metadata attribute

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -59,7 +59,7 @@ def create_event(event: EventIn, db: Session = Depends(get_db)):
     db_event = Event(
         user_id=event.userId,
         action=event.action,
-        metadata=json.dumps(event.metadata),
+        meta=json.dumps(event.metadata),
         occurred_at=event.timestamp,
     )
     db.add(db_event)

--- a/backend/models.py
+++ b/backend/models.py
@@ -38,7 +38,9 @@ class Event(Base):
     id = Column(Integer, primary_key=True, index=True)
     user_id = Column(String)
     action = Column(String)
-    metadata = Column(Text)
+    # ``metadata`` is reserved by SQLAlchemy's declarative API, so we map the
+    # database column named ``metadata`` to the ``meta`` attribute instead.
+    meta = Column("metadata", Text)
     occurred_at = Column(DateTime, default=datetime.utcnow)
 
 


### PR DESCRIPTION
## Summary
- rename SQLAlchemy `metadata` attribute to `meta`
- adjust event creation to use new attribute

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eb49d34c083258246f73808be7625