### PR TITLE
Add root redirect route

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2,12 +2,19 @@ from datetime import datetime
 import json
 
 from fastapi import FastAPI, Depends, HTTPException
+from fastapi.responses import RedirectResponse
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from .models import Lead, Event, SessionLocal, init_db
 
 app = FastAPI(title="Lead Qualifier API")
+
+
+@app.get("/", include_in_schema=False)
+def index() -> RedirectResponse:
+    """Redirect the bare root path to the interactive API docs."""
+    return RedirectResponse(url="/docs")
 
 
 def get_db():


### PR DESCRIPTION
## Summary
- add a simple redirect from `/` to the API docs

## Testing
- `pip install -q -r backend/requirements.txt` *(fails: Tunnel connection failed)*
- `python3 -m uvicorn backend.app:app --reload --port 8001` *(fails: No module named uvicorn)*

------
https://chatgpt.com/codex/tasks/task_e_685eb6cb2da0832592c7c250d47fc893