### PR TITLE
Add frontend instructions and SQL docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,62 @@ uvicorn backend.app:app --reload
 ```
 
 The API will be available at `http://localhost:8000`.
+
+## Running the Frontend
+
+The `frontend` directory contains a small React application. To install its
+dependencies and start the development server:
+
+```bash
+cd frontend
+npm install
+npm run dev # or `npm start` if using Create React App
+```
+
+The app will be available at `http://localhost:3000` by default.
+
+## SQL Queries
+
+Analytics data is stored in the `events` table. Two example queries are shown
+below using SQLite syntax.
+
+### Top 3 filters
+
+```sql
+SELECT json_extract(meta, '$.filter') AS filter,
+       COUNT(*) AS uses
+FROM events
+WHERE action = 'apply_filter'
+GROUP BY filter
+ORDER BY uses DESC
+LIMIT 3;
+```
+
+Example result:
+
+```
+filter              | uses
+--------------------+-----
+industry=Technology | 18
+size>=100           | 10
+industry=Finance    |  7
+```
+
+### Pie vs. Bar preference
+
+```sql
+SELECT json_extract(meta, '$.type') AS chart_type,
+       COUNT(*) AS views
+FROM events
+WHERE action = 'chart_type'
+GROUP BY chart_type;
+```
+
+Example result:
+
+```
+chart_type | views
+-----------+-----
+pie        | 30
+bar        | 20
+```


### PR DESCRIPTION
## Summary
- document how to install and run the React frontend
- add example SQL queries for analytics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ee127218c83259d876cadc6d44430