### PR TITLE
feat: persist session id and log refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,16 @@ python data/generate_data.py
 ```
 
 This will overwrite `data/leads.csv` with new randomly generated leads used by the API.
+
+## Event Tracking
+
+Every interaction in the dashboard is sent to the `/api/events` endpoint. A
+unique `userId` is persisted in `localStorage` so events from the same browser
+session can be correlated. Each event record includes:
+
+- `userId` – the session identifier
+- `action` – the name of the action (e.g. `refresh`)
+- `metadata` – optional JSON payload with context
+- `timestamp` – ISO 8601 time of the event
+
+These events are stored in the SQLite database for later analysis.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,6 +22,16 @@ const App: React.FC = () => {
   const [view, setView] = useState<View>('table');
   const [sourceCounts, setSourceCounts] = useState<Record<string, number>>({});
 
+  // Persist a unique identifier so events can be tied to a user session
+  const [userId] = useState(() => {
+    let id = localStorage.getItem('userId');
+    if (!id) {
+      id = crypto.randomUUID();
+      localStorage.setItem('userId', id);
+    }
+    return id;
+  });
+
   // Refs for rendering the Chart.js graph
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const chartRef = useRef<any>(null);
@@ -32,7 +42,7 @@ const App: React.FC = () => {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          userId: 'demo',
+          userId,
           action,
           metadata,
           timestamp: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- persist a unique session id in `localStorage`
- send that id with event logs
- document event tracking in README
