### PR TITLE
Add optional LLM enrichment

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,34 @@ session can be correlated. Each event record includes:
 - `timestamp` – ISO 8601 time of the event
 
 These events are stored in the SQLite database for later analysis.
+
+## LLM Enrichment
+
+If an `OPENAI_API_KEY` environment variable is present, the backend can enrich
+leads on request. Add `enrich=true` to the `/api/leads` query string and each
+lead will include additional `quality` and `summary` fields populated by
+OpenAI's `gpt-4-turbo` model. The prompt used is:
+
+```
+Classify the quality of this lead as High, Medium, or Low based on industry and
+employee size. Provide also one short sentence summary of the company. Respond
+in JSON with keys 'quality' and 'summary'.
+```
+
+Example enriched response:
+
+```json
+{
+  "id": 1,
+  "name": "Alice Smith",
+  "company": "Acme Corp",
+  "industry": "Manufacturing",
+  "size": 200,
+  "source": "PPC",
+  "created_at": "2025-06-01T10:23:00Z",
+  "quality": "High",
+  "summary": "Acme Corp is a leading manufacturing firm specializing in..."
+}
+```
+
+If no API key is configured, these fields will be `null`.

--- a/backend/app.py
+++ b/backend/app.py
@@ -73,7 +73,7 @@ async def enrich_lead(lead: Lead) -> Dict[str, Any]:
 
     try:
         resp = await openai_client.chat.completions.create(
-            model="gpt-4-turbo",
+            model="gpt-4o",
             messages=[{"role": "user", "content": prompt}],
             temperature=0,
             response_format={"type": "json_object"},

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,12 +1,20 @@
 from datetime import datetime
 import json
+import os
+import asyncio
+from typing import Any, Dict
 
-from fastapi import FastAPI, Depends, HTTPException
+from fastapi import FastAPI, Depends
 from fastapi.responses import RedirectResponse
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from .models import Lead, Event, SessionLocal, init_db
+
+import openai
+
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+openai_client = openai.AsyncOpenAI(api_key=OPENAI_API_KEY) if OPENAI_API_KEY else None
 
 app = FastAPI(title="Lead Qualifier API")
 
@@ -38,6 +46,8 @@ class LeadOut(BaseModel):
     size: int
     source: str
     created_at: datetime
+    quality: str | None = None
+    summary: str | None = None
 
     class Config:
         orm_mode = True
@@ -50,15 +60,61 @@ class EventIn(BaseModel):
     timestamp: datetime
 
 
+async def enrich_lead(lead: Lead) -> Dict[str, Any]:
+    if not openai_client:
+        return {"quality": None, "summary": None}
+
+    prompt = (
+        "Classify the quality of this lead as High, Medium, or Low based on "
+        "industry and employee size. Provide also one short sentence summary "
+        "of the company. Respond in JSON with keys 'quality' and 'summary'.\n"  # noqa
+        f"Company: {lead.company}\nIndustry: {lead.industry}\nSize: {lead.size}"
+    )
+
+    try:
+        resp = await openai_client.chat.completions.create(
+            model="gpt-4-turbo",
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0,
+            response_format={"type": "json_object"},
+        )
+        content = resp.choices[0].message.content
+        data = json.loads(content)
+        return {
+            "quality": data.get("quality"),
+            "summary": data.get("summary"),
+        }
+    except Exception:
+        return {"quality": None, "summary": None}
+
+
 @app.get("/api/leads", response_model=list[LeadOut])
-def get_leads(industry: str | None = None, size: int | None = None, db: Session = Depends(get_db)):
+async def get_leads(
+    industry: str | None = None,
+    size: int | None = None,
+    enrich: bool = False,
+    db: Session = Depends(get_db),
+):
     query = db.query(Lead)
     if industry:
         query = query.filter(Lead.industry == industry)
     if size:
         query = query.filter(Lead.size >= size)
     leads = query.all()
-    return leads
+
+    results: list[LeadOut] = []
+    if enrich:
+        tasks = [enrich_lead(l) for l in leads]
+        enrichments = await asyncio.gather(*tasks)
+        for lead, info in zip(leads, enrichments):
+            lead_data = LeadOut.from_orm(lead)
+            lead_data.quality = info["quality"]
+            lead_data.summary = info["summary"]
+            results.append(lead_data)
+    else:
+        results = [LeadOut.from_orm(l) for l in leads]
+
+    return results
 
 
 @app.post("/api/events", status_code=201)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 sqlalchemy
 pydantic
+openai>=1.0.0


### PR DESCRIPTION
## Summary
- enrich lead data using OpenAI when `enrich=true`
- document enrichment behaviour in README
- add `openai` to backend requirements
- use GPT-4 for lead enrichment

## Testing
- `python -m py_compile backend/app.py backend/models.py data/generate_data.py`
- `npm run build