### PR TITLE
Fix missing quality/summary in dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,10 @@ These events are stored in the SQLite database for later analysis.
 ## LLM Enrichment
 
 If an `OPENAI_API_KEY` environment variable is present, the backend can enrich
-leads on request. Add `enrich=true` to the `/api/leads` query string and each
-lead will include additional `quality` and `summary` fields populated by
-OpenAI's `gpt-4-turbo` model. The prompt used is:
+leads on request. The React dashboard now sends the `enrich=true` flag
+automatically, so with a valid API key each lead row will include additional
+`quality` and `summary` fields populated by OpenAI's `gpt-4-turbo` model. The
+prompt used is:
 
 ```
 Classify the quality of this lead as High, Medium, or Low based on industry and

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -41,6 +41,7 @@ const App: React.FC = () => {
     const params = new URLSearchParams();
     if (industry) params.append('industry', industry);
     if (size) params.append('size', size.toString());
+    params.append('enrich', 'true');
     const res = await fetch(`/api/leads?${params.toString()}`);
     const data: Lead[] = await res.json();
     setLeads(data);

--- a/frontend/src/components/LeadTable.tsx
+++ b/frontend/src/components/LeadTable.tsx
@@ -8,6 +8,8 @@ export interface Lead {
   size: number;
   source: string;
   created_at: string;
+  quality?: string | null;
+  summary?: string | null;
 }
 
 const LeadTable: React.FC<{ leads: Lead[] }> = ({ leads }) => (
@@ -20,6 +22,8 @@ const LeadTable: React.FC<{ leads: Lead[] }> = ({ leads }) => (
         <th>Size</th>
         <th>Source</th>
         <th>Created</th>
+        <th>Quality</th>
+        <th>Summary</th>
       </tr>
     </thead>
     <tbody>
@@ -31,6 +35,8 @@ const LeadTable: React.FC<{ leads: Lead[] }> = ({ leads }) => (
           <td>{lead.size}</td>
           <td>{lead.source}</td>
           <td>{new Date(lead.created_at).toLocaleDateString()}</td>
+          <td>{lead.quality ?? '-'}</td>
+          <td>{lead.summary ?? '-'}</td>
         </tr>
       ))}
     </tbody>


### PR DESCRIPTION
## Summary
- request enriched leads from the API in the React dashboard
- show quality and summary columns in the table
- document that the dashboard automatically requests enrichment

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68604f11d0948325929062c82efa75fe