### PR TITLE
Add reset filter with spinner

### DIFF
--- a/frontend/src/components/FilterBar.tsx
+++ b/frontend/src/components/FilterBar.tsx
@@ -9,7 +9,9 @@ interface Props {
   onIndustryChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
   onSizeChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onRefresh: () => void;
+  onReset: () => void;
   onToggleView: (v: View) => void;
+  loading: boolean;
 }
 
 const FilterBar: React.FC<Props> = ({
@@ -19,7 +21,9 @@ const FilterBar: React.FC<Props> = ({
   onIndustryChange,
   onSizeChange,
   onRefresh,
+  onReset,
   onToggleView,
+  loading,
 }) => (
   <div className="controls">
     <label>
@@ -43,6 +47,10 @@ const FilterBar: React.FC<Props> = ({
       />
     </label>
     <button onClick={onRefresh}>Refresh</button>
+    <button onClick={onReset} disabled={loading} className="reset-button">
+      Reset
+      {loading && <span className="spinner" />}
+    </button>
     <div className="view-toggle">
       <button
         onClick={() => onToggleView('table')}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -42,9 +42,32 @@ body {
   cursor: pointer;
 }
 
+.controls button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 .controls button.active,
 .controls button:hover {
   background: #e0e0e0;
+}
+
+.spinner {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 2px solid #ccc;
+  border-top-color: #333;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+  margin-left: 0.5rem;
+  vertical-align: middle;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .leads-table {


### PR DESCRIPTION
## Summary
- add reset filter button to the filter bar
- show spinner while leads are loading
- disable buttons while loading for better UX
