### PR TITLE
Add sorting to leads table

### DIFF
--- a/frontend/src/components/LeadTable.tsx
+++ b/frontend/src/components/LeadTable.tsx
@@ -12,35 +12,56 @@ export interface Lead {
   summary?: string | null;
 }
 
-const LeadTable: React.FC<{ leads: Lead[] }> = ({ leads }) => (
-  <table className="leads-table">
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Company</th>
-        <th>Industry</th>
-        <th>Size</th>
-        <th>Source</th>
-        <th>Created</th>
-        <th>Quality</th>
-        <th>Summary</th>
-      </tr>
-    </thead>
-    <tbody>
-      {leads.map((lead) => (
-        <tr key={lead.id}>
-          <td>{lead.name}</td>
-          <td>{lead.company}</td>
-          <td>{lead.industry}</td>
-          <td>{lead.size}</td>
-          <td>{lead.source}</td>
-          <td>{new Date(lead.created_at).toLocaleDateString()}</td>
-          <td>{lead.quality ?? '-'}</td>
-          <td>{lead.summary ?? '-'}</td>
+interface Props {
+  leads: Lead[];
+  sortKey: keyof Lead | '';
+  sortDir: 'asc' | 'desc';
+  onSort: (key: keyof Lead) => void;
+}
+
+const LeadTable: React.FC<Props> = ({ leads, sortKey, sortDir, onSort }) => {
+  const headers: { key: keyof Lead; label: string }[] = [
+    { key: 'name', label: 'Name' },
+    { key: 'company', label: 'Company' },
+    { key: 'industry', label: 'Industry' },
+    { key: 'size', label: 'Size' },
+    { key: 'source', label: 'Source' },
+    { key: 'created_at', label: 'Created' },
+    { key: 'quality', label: 'Quality' },
+    { key: 'summary', label: 'Summary' },
+  ];
+
+  return (
+    <table className="leads-table">
+      <thead>
+        <tr>
+          {headers.map((h) => (
+            <th
+              key={h.key}
+              onClick={() => onSort(h.key)}
+              className={sortKey === h.key ? `sort-${sortDir}` : undefined}
+            >
+              {h.label}
+            </th>
+          ))}
         </tr>
-      ))}
-    </tbody>
-  </table>
-);
+      </thead>
+      <tbody>
+        {leads.map((lead) => (
+          <tr key={lead.id}>
+            <td>{lead.name}</td>
+            <td>{lead.company}</td>
+            <td>{lead.industry}</td>
+            <td>{lead.size}</td>
+            <td>{lead.source}</td>
+            <td>{new Date(lead.created_at).toLocaleDateString()}</td>
+            <td>{lead.quality ?? '-'}</td>
+            <td>{lead.summary ?? '-'}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};
 
 export default LeadTable;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -89,3 +89,22 @@ body {
 .leads-table tbody tr:nth-child(even) {
   background: #fbfbfb;
 }
+
+.leads-table th {
+  cursor: pointer;
+  user-select: none;
+}
+
+.leads-table th.sort-asc::after,
+.leads-table th.sort-desc::after {
+  margin-left: 0.25rem;
+  font-size: 0.7rem;
+}
+
+.leads-table th.sort-asc::after {
+  content: '▲';
+}
+
+.leads-table th.sort-desc::after {
+  content: '▼';
+}


### PR DESCRIPTION
## Summary
- allow clicking column headers in the leads table to sort
- keep sorting state in `App.tsx`
- show arrow indicators for active sort

