### PR TITLE
Use chart.js package

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,8 +7,6 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
-    <!-- Load Chart.js from CDN for simple chart rendering -->
-    <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,8 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "chart.js": "^4.4.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/frontend/src/components/SourceChart.tsx
+++ b/frontend/src/components/SourceChart.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef } from 'react';
-
-declare const Chart: any;
+import Chart from 'chart.js/auto';
 
 interface Props {
   counts: Record<string, number>;
@@ -8,7 +7,7 @@ interface Props {
 
 const SourceChart: React.FC<Props> = ({ counts }) => {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
-  const chartRef = useRef<any>(null);
+  const chartRef = useRef<Chart | null>(null);
 
   useEffect(() => {
     if (!canvasRef.current) return;

--- a/frontend/src/types/chartjs-auto.d.ts
+++ b/frontend/src/types/chartjs-auto.d.ts
@@ -1,0 +1,6 @@
+declare module 'chart.js/auto' {
+  export default class Chart {
+    constructor(ctx: CanvasRenderingContext2D, config: any);
+    destroy(): void;
+  }
+}


### PR DESCRIPTION
## Summary
- add `chart.js` to dependencies
- import the package in `SourceChart` instead of relying on the global
- drop the CDN script tag from the frontend HTML
